### PR TITLE
fix:win下thinkphp获取pid方法错误

### DIFF
--- a/src/ThinkPHP/Worker.php
+++ b/src/ThinkPHP/Worker.php
@@ -158,7 +158,7 @@ class Worker extends \Psc\Worker\Worker
         fwrite(STDOUT, sprintf(
             "Worker %s@%d started.\n",
             $this->getName(),
-            Kernel::getInstance()->supportProcessControl() ? getmypid() : posix_getpid()
+            Kernel::getInstance()->supportProcessControl() ? posix_getpid() : getmypid()
         ));
 
         /*** register loop timer*/


### PR DESCRIPTION
win下Kernel::getInstance()->supportProcessControl()是false,三元运算取反了.